### PR TITLE
Fix duplicate migration application when db.migrate() is run multiple times

### DIFF
--- a/src/Database.js
+++ b/src/Database.js
@@ -169,7 +169,7 @@ class Database {
 
     // Get the list of already applied migrations
     let dbMigrations = await this.all(
-      `SELECT id, name, up, down FROM "${table}" ORDER BY id DESC`
+      `SELECT id, name, up, down FROM "${table}" ORDER BY id ASC`
     );
 
     // Undo migrations that exist only in the database but not in files,


### PR DESCRIPTION
On a partially or fully up-to-date db, calling `db.migrate()` would result in duplicate execution of migrations because `lastMigrationId` [retrieved the first migration id due to the DESC ordering of the dbMigrations query](https://github.com/kriasoft/node-sqlite/blob/master/src/Database.js#L197).

This throws an error in the migration script if it isn't idempotent, or the following error in the migrations table when it tries to insert the pre-existing migration with the same id:

```
{ Error: SQLITE_CONSTRAINT: UNIQUE constraint failed: migrations.id
    at Error (native) errno: 19, code: 'SQLITE_CONSTRAINT' }
```

My fix flips the order of the `dbMigrations` query so the highest migration is at the end.
